### PR TITLE
Sprite grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Code:
 
   - Depends on [gl-react-native][gl-rn]
   - Works on IOS and Android
-  - Supports both [horizontal][h-sprite] and [vertical][v-sprite] spritesheets
+  - Supports [horizontal][h-sprite], [vertical][v-sprite] and grid spritesheets
   - Play/Pause support
   - Configurable animation speed
   - Touch responsive
@@ -43,7 +43,7 @@ Code:
 | prop | type | description | required |
 |------|------|-------------|----------|
 | **source** | string | Url of spritesheet image | yes |
-| **sequence** | array | Array of numbers between 0 and 1 that define the sequence of animation | yes |
+| **sequence** | array | Array of numbers between 0 and 1 that define the sequence of animation, or, in the case of a sprite grid, an array of pairs of numbers between 0 and 1| yes |
 | **loop** | boolean | Repeat the animation when it completes (Default: `true`) | no |
 | **fps** | integer | Frames per second (Default: `2`) | no |
 | **isPlaying** | boolean | Play/Pause the animation (Default: `true`) | no |
@@ -58,7 +58,7 @@ Code:
 - 360-View
 
 ### Installation
-- Setup `RNGLPackage` by following [this][gl-rn] guide for Android and IOS 
+- Setup `RNGLPackage` by following [this][gl-rn] guide for Android and IOS
 - `npm install --save rn-sprite`
 
 ### Todo

--- a/src/frame.js
+++ b/src/frame.js
@@ -25,6 +25,8 @@ export default GL.createComponent(({
     source,
     size,
     move,
+    rows,
+    cols,
     position,
   }) => {
     const { width: imageWidth, height: imageHeight } = size
@@ -56,8 +58,20 @@ export default GL.createComponent(({
       canvasSize[1],
     ]
 
-    rectangle[0] = move === 'horizontal' ? rectangle[0] : Math.max(0, Math.min(rectangle[0], imageWidth - canvasSize[0]))
-    rectangle[1] = move === 'vertical' ? rectangle[1] : Math.max(0, Math.min(rectangle[1], imageHeight - canvasSize[1]))
+    if ( move === 'horizontal' ) {
+      rectangle[1] = Math.max(0, Math.min(rectangle[1], imageHeight - canvasSize[1]))
+    }
+    else if ( move === 'vertical' ) {
+      rectangle[0] = Math.max(0, Math.min(rectangle[0], imageWidth - canvasSize[0]))
+    }
+    else if ( move === 'grid' ) {
+      rectangle = [
+        imageWidth * position[0] - imageWidth / (cols*2),
+        imageHeight * position[1] - imageHeight / (rows*2),
+        imageWidth / cols,
+        imageHeight / rows,
+      ]
+    }
 
     let crop = [
       rectangle[0] / imageWidth,

--- a/src/frame.js
+++ b/src/frame.js
@@ -2,8 +2,8 @@ import React, { PropTypes } from 'react'
 import GL from 'gl-react'
 
 const shaders = GL.Shaders.create({
-	frame: {
-		frag: `
+  frame: {
+    frag: `
 precision highp float;
 varying vec2 uv;
 uniform sampler2D t;
@@ -16,62 +16,62 @@ void main () {
   gl_FragColor =
     texture2D(t, p);
 }`
-	}
+  }
 })
 
 export default GL.createComponent(({
-		width,
-		height,
-		source,
-		size,
-		move,
-		position,
-	}) => {
-	  const { width: imageWidth, height: imageHeight } = size
-	  const viewportRatio = width / height
-	  const imageRatio = imageWidth / imageHeight
-	  const ratio = Math.max(viewportRatio, imageRatio)
+    width,
+    height,
+    source,
+    size,
+    move,
+    position,
+  }) => {
+    const { width: imageWidth, height: imageHeight } = size
+    const viewportRatio = width / height
+    const imageRatio = imageWidth / imageHeight
+    const ratio = Math.max(viewportRatio, imageRatio)
 
-	  var canvasSize = [
-	  	(viewportRatio / ratio) * imageWidth,
-	  	(imageRatio / ratio) * imageHeight,
-	  ]
+    var canvasSize = [
+      (viewportRatio / ratio) * imageWidth,
+      (imageRatio / ratio) * imageHeight,
+    ]
 
-	  let r = canvasSize[0] / canvasSize[1]
+    let r = canvasSize[0] / canvasSize[1]
 
-	  if (canvasSize[0] > imageWidth) {
-	  	canvasSize[0] = imageWidth
-	  	canvasSize[1] = ~~(canvasSize[0] / r)
-	  }
+    if (canvasSize[0] > imageWidth) {
+      canvasSize[0] = imageWidth
+      canvasSize[1] = ~~(canvasSize[0] / r)
+    }
 
-	  if (canvasSize[1] > imageHeight) {
-	  	canvasSize[1] = imageHeight
-	  	canvasSize[0] = ~~(canvasSize[1] * r)
-	  }
+    if (canvasSize[1] > imageHeight) {
+      canvasSize[1] = imageHeight
+      canvasSize[0] = ~~(canvasSize[1] * r)
+    }
 
-	  let rectangle = [
-	  	imageWidth * position[0] - canvasSize[0] / 2,
-	  	imageHeight * position[1] - canvasSize[1] / 2,
-	  	canvasSize[0],
-	  	canvasSize[1],
-	  ]
+    let rectangle = [
+      imageWidth * position[0] - canvasSize[0] / 2,
+      imageHeight * position[1] - canvasSize[1] / 2,
+      canvasSize[0],
+      canvasSize[1],
+    ]
 
-	  rectangle[0] = move === 'horizontal' ? rectangle[0] : Math.max(0, Math.min(rectangle[0], imageWidth - canvasSize[0]))
-	  rectangle[1] = move === 'vertical' ? rectangle[1] : Math.max(0, Math.min(rectangle[1], imageHeight - canvasSize[1]))
+    rectangle[0] = move === 'horizontal' ? rectangle[0] : Math.max(0, Math.min(rectangle[0], imageWidth - canvasSize[0]))
+    rectangle[1] = move === 'vertical' ? rectangle[1] : Math.max(0, Math.min(rectangle[1], imageHeight - canvasSize[1]))
 
-	  let crop = [
-	  	rectangle[0] / imageWidth,
-	  	rectangle[1] / imageHeight,
-	  	rectangle[2] / imageWidth,
-	  	rectangle[3] / imageHeight,
-	  ]
+    let crop = [
+      rectangle[0] / imageWidth,
+      rectangle[1] / imageHeight,
+      rectangle[2] / imageWidth,
+      rectangle[3] / imageHeight,
+    ]
 
-	  return <GL.Node
-	  	shader = { shaders.frame}
-	  	uniforms = {{
-	  		t: source,
-	  		crop,
-	  	}} />
-	}, {
-	displayName: "Frame"
+    return <GL.Node
+      shader = { shaders.frame}
+      uniforms = {{
+        t: source,
+        crop,
+      }} />
+  }, {
+  displayName: "Frame"
 })

--- a/src/rnsprite.js
+++ b/src/rnsprite.js
@@ -23,12 +23,34 @@ export default class Sprite extends Component {
       frames: 0,
     }
 
-    this.move = move !== 'vertical' ? 'horizontal' : move
+    this.move = move
     this.speed = 1000 / fps
     this.loopInterval = null
     this.loop = loop
 
     this.totalFrames = sequence.length
+    if ( this.props.rows ) {
+      this.rows = this.props.rows;
+    } else if ( this.move === 'horizontal' ) {
+      this.rows = 1;
+    } else if ( this.move === 'vertical' ) {
+      this.rows = this.totalFrames;
+    } else if ( this.move === 'grid' ) {
+      this.rows = Math.ceil(Math.sqrt(this.totalFrames));
+    } else {
+      this.rows = 1;
+    }
+    if ( this.props.cols ) {
+      this.cols = this.props.cols;
+    } else if ( this.move === 'horizontal' ) {
+      this.cols = this.totalFrames;
+    } else if ( this.move === 'vertical' ) {
+      this.cols = 1;
+    } else if ( this.move === 'grid' ) {
+      this.cols = Math.ceil(Math.sqrt(this.totalFrames));
+    } else {
+      this.cols = 1;
+    }
 
     this.play = this.play.bind(this)
     this.stop = this.stop.bind(this)
@@ -118,6 +140,14 @@ export default class Sprite extends Component {
     const { imageSize } = this.state
     if (!imageSize) return <View />
 
+    this.position = [0, 0];
+    if ( this.move === 'vertical' )
+      this.position[1] = this.state.current;
+    else if ( this.move === 'horizontal' )
+      this.position[0] = this.state.current;
+    else if ( this.move === 'grid' )
+      this.position = this.state.current;
+
     return (
       <Surface
         onStartShouldSetResponderCapture={ () => true }
@@ -131,7 +161,9 @@ export default class Sprite extends Component {
           <Frame source = { this.props.source }
           size = { imageSize }
           move = { this.move }
-          position = { this.move === 'vertical' ? [ 0, this.state.current ] : [ this.state.current, 0 ] } />
+          rows = { this.rows }
+          cols = { this.cols }
+          position = { this.position } />
       </Surface>
     );
   }


### PR DESCRIPTION
This adds support for sprite grids. I ran in to some trouble with maximum image sizes and was able to increase the number of frames and frame sizes by creating a grid of images rather than a film strip. It alters some of the logic of the horizontal and vertical checks which I've only check rudimentarily.

The `sequence` array for grids is slightly different and the Sprite also accepts `rows` and `cols` hints.

If you merge the white space fixes pull request first then this one should look better.